### PR TITLE
Improve & clarify resampling

### DIFF
--- a/Audio/AudioResample.cs
+++ b/Audio/AudioResample.cs
@@ -33,82 +33,64 @@ namespace MultiplayerChat.Audio;
 
 public static class AudioResample
 {
-    public static int Resample(float[] source, float[] target, int sourceFrequency,
-        int outputFrequency, int outputChannels = 1)
+    public static int ResampledSampleCount(int sampleCount, int sourceFrequency, int targetFrequency)
     {
-        if (sourceFrequency == outputFrequency)
+        return sampleCount * targetFrequency / sourceFrequency;
+    }
+
+    public static int Resample(float[] source, float[] target, int sourceFrequency, int targetFrequency)
+    {
+        int sourceLength = source.Length;
+        int targetLength = target.Length;
+
+        if (sourceFrequency == targetFrequency)
             throw new ArgumentException("Source and target frequencies cannot be the same");
 
-        var ratio = sourceFrequency / (float)outputFrequency;
+        float sampleRatio = (float)sourceFrequency / (float)targetFrequency;
 
-        var sourceLength = source.Length;
-        var targetLength = target.Length;
+        var requiredSize = ResampledSampleCount(sourceLength, sourceFrequency, targetFrequency);
+        if (requiredSize < targetLength)
+            throw new ArgumentException(
+                $"target's length of '{targetLength}' does not meet the minimum length of '{requiredSize}'.");
 
-        var length = 0;
-        
-        if (ratio % 1f <= float.Epsilon)
+        var writtenLength = 0;
+        var remainder = sampleRatio % 1.0f;
+        // basically an integer
+        if (remainder < float.Epsilon)
         {
-            var intRatio = Mathf.RoundToInt(ratio);
-            var sizeRequired = sourceLength * intRatio * outputChannels;
-            
-            if (sizeRequired > target.Length)
-                throw new ArgumentException(
-                    $"target's length of '{target.Length}' does not meet the minimum length of '{sizeRequired}'.");
-            
-            for (var i = 0; i < (targetLength / outputChannels) && (i * intRatio) < sourceLength; i++)
+            int intSampleRatio = Mathf.RoundToInt(sampleRatio);
+            for (int i = 0; i < targetLength && i * intSampleRatio < sourceLength; i++)
             {
-                for (var j = 0; j < outputChannels; j++)
-                {
-                    var targetIndex = i * outputChannels + j;
-                    var sourceSample = source[i * intRatio];
-                    target[targetIndex] = sourceSample;
-                    length++;
-                }
+                target[i] = source[i * intSampleRatio];
+                writtenLength++;
             }
         }
         else
         {
-            if (ratio > 1f)
+            // we need more samples!
+            if (targetFrequency > sourceFrequency)
             {
-                var sizeRequired = Mathf.CeilToInt(sourceLength * ratio);
-                
-                if (sizeRequired > target.Length)
-                    throw new ArgumentException(
-                        $"target's length of '{target.Length}' does not meet the minimum length of '{sizeRequired}'.");
-                
-                for (var i = 0; i < (targetLength / outputChannels) && Mathf.CeilToInt(i * ratio) < sourceLength; i++)
+                for (int i = 0; i < targetLength && Mathf.CeilToInt(i * sampleRatio) < sourceLength; i++)
                 {
-                    for (var j = 0; j < outputChannels; j++)
-                    {
-                        var targetIndex = i * outputChannels + j;
-                        var sourceSample = Mathf.Lerp(source[Mathf.FloorToInt(i * ratio)],
-                            source[Mathf.CeilToInt(i * ratio)], ratio % 1);
-                        target[targetIndex] = sourceSample;
-                        length++;
-                    }
+                    var lower = Mathf.FloorToInt(i * sampleRatio);
+                    var upper = Mathf.CeilToInt(i * sampleRatio);
+                    var sample = Mathf.Lerp(source[lower], source[upper], remainder);
+                    target[i] = sample;
+                    writtenLength++;
                 }
             }
+            // we need less samples!
             else
             {
-                var sizeRequired = Mathf.FloorToInt(sourceLength * ratio);
-                
-                if (sizeRequired > target.Length)
-                    throw new ArgumentException(
-                        $"target's length of '{target.Length}' does not meet the minimum length of '{sizeRequired}'.");
-                
-                for (var i = 0; i < (targetLength / outputChannels) && Mathf.FloorToInt(i * ratio) < sourceLength; i++)
+                for (int i = 0; i < targetLength && Mathf.FloorToInt(i * sampleRatio) < sourceLength; i++)
                 {
-                    for (var j = 0; j < outputChannels; j++)
-                    {
-                        var targetIndex = i * outputChannels + j;
-                        var sourceSample = source[Mathf.FloorToInt(i * ratio)];
-                        target[targetIndex] = sourceSample;
-                        length++;
-                    }
+                    var sampleIdx = Mathf.FloorToInt(i * sampleRatio);
+                    target[i] = source[sampleIdx];
+                    writtenLength++;
                 }
             }
         }
-
-        return length;
+        
+        return writtenLength;
     }
 }

--- a/Audio/AudioResample.cs
+++ b/Audio/AudioResample.cs
@@ -35,7 +35,7 @@ public static class AudioResample
 {
     public static int ResampledSampleCount(int sampleCount, int sourceFrequency, int targetFrequency)
     {
-        return sampleCount * targetFrequency / sourceFrequency;
+        return (int)((float)sampleCount * (float)targetFrequency / (float)sourceFrequency);
     }
 
     public static int Resample(float[] source, float[] target, int sourceFrequency, int targetFrequency)
@@ -49,7 +49,7 @@ public static class AudioResample
         float sampleRatio = (float)sourceFrequency / (float)targetFrequency;
 
         var requiredSize = ResampledSampleCount(sourceLength, sourceFrequency, targetFrequency);
-        if (requiredSize < targetLength)
+        if (targetLength < requiredSize)
             throw new ArgumentException(
                 $"target's length of '{targetLength}' does not meet the minimum length of '{requiredSize}'.");
 

--- a/Audio/VoiceManager.cs
+++ b/Audio/VoiceManager.cs
@@ -143,10 +143,10 @@ public class VoiceManager : MonoBehaviour, IInitializable, IDisposable
         }
         else
         {
-            copySourceBuffer = _resampleBuffer;
             EnsureResampleBufferSize(AudioResample.ResampledSampleCount(samples.Length, captureFrequency, outputFrequency));
-            copySourceLength = AudioResample.Resample(samples, _resampleBuffer,
-                captureFrequency, outputFrequency);
+
+            copySourceBuffer = _resampleBuffer;
+            copySourceLength = AudioResample.Resample(samples, _resampleBuffer, captureFrequency, outputFrequency);
         }
 
         // Continuously write to encode buffer until it reaches the target frame length, then encode

--- a/Audio/VoiceManager.cs
+++ b/Audio/VoiceManager.cs
@@ -25,7 +25,7 @@ public class VoiceManager : MonoBehaviour, IInitializable, IDisposable
     private readonly Encoder _opusEncoder;
     private readonly Decoder _opusDecoder;
     
-    private readonly float[] _resampleBuffer;
+    private float[] _resampleBuffer;
     private readonly float[] _encodeSampleBuffer;
     private readonly byte[] _encodeOutputBuffer;
     private int _encodeSampleIndex;
@@ -117,6 +117,14 @@ public class VoiceManager : MonoBehaviour, IInitializable, IDisposable
 
     #region Encode / Send
 
+    private void EnsureResampleBufferSize(int minimumSize)
+    {
+        if (_resampleBuffer.Length < minimumSize)
+        {
+            _resampleBuffer = new float[minimumSize];
+        }
+    }
+
     private void HandleMicrophoneFragment(float[] samples, int captureFrequency)
     {
         // Apply gain
@@ -136,6 +144,7 @@ public class VoiceManager : MonoBehaviour, IInitializable, IDisposable
         else
         {
             copySourceBuffer = _resampleBuffer;
+            EnsureResampleBufferSize(AudioResample.ResampledSampleCount(samples.Length, captureFrequency, outputFrequency));
             copySourceLength = AudioResample.Resample(samples, _resampleBuffer,
                 captureFrequency, outputFrequency);
         }


### PR DESCRIPTION
This solves the following problems:
 - original implementation didn't correctly check the size of the target buffer in the required size check
 - original implementation had (imo) ambiguous naming for things making it harder to understand
 - original implementation didn't resize the sampling buffer if it ever was too small (it would very quickly be too small! 512 samples @16k would not fit into a 960 sized buffer upsampled to 48k)

This tweak comes with regressions however:
 - VoiceManager._resampleBuffer is no longer readonly because we need to be able to resize it
 - AudioResample.Resample no longer accepts a channel count argument, although that was not used